### PR TITLE
Allow a larger length in encodeArray

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -35,7 +35,7 @@ export function encode(value: number, max = 0xffff) {
 }
 
 export function encodeArray(values: {length: number, readonly [i: number]: number}, max = 0xffff) {
-  let result = '"' + encode(values.length)
+  let result = '"' + encode(values.length, 0xffffffff)
   for (let i = 0; i < values.length; i++) result += encode(values[i], max)
   result += '"'
   return result


### PR DESCRIPTION
Complex grammars can apparently reach the current 2^16 limit of values during `buildParserFile`. The `max` setting is important for values inside the array, since they're tied to a certain typed array (e.g. `Uint16Array`), but the length of the array is independent of that, anyway. The corresponding part in `decode` is https://github.com/lezer-parser/lezer/blob/0.8.0/src/decode.ts#L22