### PR TITLE
test: allow passing of additional configuration

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -152,12 +152,16 @@ export function fileTests(file: string, fileName: string, mayIgnore = defaultIgn
     let m = caseExpr.exec(file)
     if (!m) throw new Error(`Unexpected file format in ${fileName} around\n\n${toLineContext(file, lastIndex)}`)
 
+    let [ _, name, configStr ] = /(.*?)(\{.*?\})?$/.exec(m[1])!;
+
+    const extraConfig = configStr ? JSON.parse(configStr) : {};
+
     let text = m[2].trim(), expected = m[3]
     tests.push({
-      name: m[1],
+      name,
       run(parser: Parser) {
         let strict = !/⚠|\.\.\./.test(expected)
-        testTree(parser.parse(text, {strict}), expected, mayIgnore)
+        testTree(parser.parse(text, {strict, ...extraConfig}), expected, mayIgnore)
       }
     })
     lastIndex = m.index + m[0].length

--- a/test/cases/AlternativeTop.txt
+++ b/test/cases/AlternativeTop.txt
@@ -1,0 +1,28 @@
+@top A { "a" }
+
+@top B { "b" }
+
+@tokens {
+  "a" "b"
+}
+
+
+# Recognize "a"
+
+a
+
+==> A
+
+
+# Recognize "a" { "top": "A" }
+
+a
+
+==> A
+
+
+# Recognize "b" { "top": "B" }
+
+b
+
+==> B


### PR DESCRIPTION
Allows tests to encode additional parser configuration in the test
title. This allows the test to, i.e. override the `top` to use
when parsing the test expression.

Example:
```
Other

==>

OtherTop()
```
Closes https://github.com/lezer-parser/lezer/issues/24