### PR TITLE
test: log parse error with line context

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -130,8 +130,16 @@ export function testTree(tree: Tree, expect: string, mayIgnore = defaultIgnore) 
     throw new Error(`Unexpected end of tree. Expected ${stack[0].slice(pos[0]).map(s => s.name).join(", ")} at ${tree.length}\n${tree}`)
 }
 
+/**
+ * Returns a line context for the given file.
+ *
+ * @param {string} file
+ * @param {number} index
+ */
 function toLineContext(file: string, index: number) {
-  const endIndex = Math.min(index + 80, file.length);
+  const endEol = file.indexOf('\n', index + 80);
+
+  const endIndex = endEol === -1 ? file.length : endEol;
 
   return file.substring(index, endIndex).split(/\n/).map(str => '  | ' + str).join('\n');
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -130,12 +130,20 @@ export function testTree(tree: Tree, expect: string, mayIgnore = defaultIgnore) 
     throw new Error(`Unexpected end of tree. Expected ${stack[0].slice(pos[0]).map(s => s.name).join(", ")} at ${tree.length}\n${tree}`)
 }
 
+function toLineContext(file: string, index: number) {
+  const endIndex = Math.min(index + 80, file.length);
+
+  return file.substring(index, endIndex).split(/\n/).map(str => '  | ' + str).join('\n');
+}
+
 export function fileTests(file: string, fileName: string, mayIgnore = defaultIgnore) {
   let caseExpr = /\s*#\s*(.*)\n([^]*?)==+>([^]*?)(?:$|\n+(?=#))/gy
   let tests: {name: string, run(parser: Parser): void}[] = []
+  let lastIndex = 0;
   for (;;) {
     let m = caseExpr.exec(file)
-    if (!m) throw new Error("Unexpected file format in " + fileName)
+    if (!m) throw new Error(`Unexpected file format in ${fileName} around\n\n${toLineContext(file, lastIndex)}`)
+
     let text = m[2].trim(), expected = m[3]
     tests.push({
       name: m[1],
@@ -144,7 +152,8 @@ export function fileTests(file: string, fileName: string, mayIgnore = defaultIgn
         testTree(parser.parse(text, {strict}), expected, mayIgnore)
       }
     })
-    if (m.index + m[0].length == file.length) break
+    lastIndex = m.index + m[0].length
+    if (lastIndex == file.length) break
   }
   return tests
 }

--- a/test/test-test.ts
+++ b/test/test-test.ts
@@ -13,14 +13,20 @@ b
 
 # Broken Spec
 
-b
+bbbb bbbb bbbb bbbb
+bbbb bbbb bbbb bbbb
+bbbb bbbb bbbb bbbb
+bbbb bbbb bbbb bbbb aaaa
+bbbb
 `
     const expectedError = `Unexpected file format in test-error.txt around
 
   | # Broken Spec
   |${ ' ' }
-  | b
-  | `;
+  | bbbb bbbb bbbb bbbb
+  | bbbb bbbb bbbb bbbb
+  | bbbb bbbb bbbb bbbb
+  | bbbb bbbb bbbb bbbb aaaa`;
 
     const file = "test-error.txt"
 

--- a/test/test-test.ts
+++ b/test/test-test.ts
@@ -1,0 +1,36 @@
+import {fileTests} from "../dist/test.cjs"
+
+describe("test", () => {
+
+  it("handle parser error", () => {
+
+    const content = `
+# Working Spec
+
+b
+
+==> B
+
+# Broken Spec
+
+b
+`
+    const expectedError = `Unexpected file format in test-error.txt around
+
+  | # Broken Spec
+  |${ ' ' }
+  | b
+  | `;
+
+    const file = "test-error.txt"
+
+    try {
+      fileTests(content, file)
+    } catch (err) {
+      if (err.message !== expectedError) {
+        throw err;
+      }
+    }
+  })
+
+})


### PR DESCRIPTION
Fail with context when failing to parse spec:

```
Error: Unexpected file format in test-error.txt around

  | # Broken Spec
  |
  | b
  |
```

Related to https://github.com/lezer-parser/lezer/issues/25