### PR TITLE
Fix test case regex to work with all type of EOL characters

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -145,7 +145,7 @@ function toLineContext(file: string, index: number) {
 }
 
 export function fileTests(file: string, fileName: string, mayIgnore = defaultIgnore) {
-  let caseExpr = /\s*#\s*(.*)\n([^]*?)==+>([^]*?)(?:$|\n+(?=#))/gy
+  let caseExpr = /\s*#\s*(.*)(?:\r\n|\r|\n)([^]*?)==+>([^]*?)(?:$|(?:\r\n|\r|\n)+(?=#))/gy
   let tests: {name: string, run(parser: Parser): void}[] = []
   let lastIndex = 0;
   for (;;) {


### PR DESCRIPTION
When trying to run the tests for the lezer/json library I stumbled upon this issue on a Windows pc. The EOL charactes where apparently replaced with `\r\n` and the regex failed.

This PR changes the regex to match `\n`, `\r` and `\r\n`.