### PR TITLE
Don't store node names as a joined string

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -342,7 +342,7 @@ class Builder {
       states,
       stateData: data.finish(),
       goto: computeGotoTable(table),
-      nodeNames: nodeTypes.filter(t => t.id < minRepeatTerm).map(t => t.nodeName).join(" "),
+      nodeNames: nodeTypes.filter(t => t.id < minRepeatTerm).map(t => t.nodeName),
       nodeProps,
       skippedTypes,
       maxTerm,


### PR DESCRIPTION
This stores the node names as an array of strings instead of a joined string. It is preparatory work for fixing https://github.com/lezer-parser/lezer/issues/35 (and depends on the corresponding change in `lezer`.